### PR TITLE
Add sign before unit when converting negative numbers

### DIFF
--- a/coffee/number_helpers.coffee
+++ b/coffee/number_helpers.coffee
@@ -6,34 +6,22 @@ class @NumberHelpers
     _delimiter  = opts.delimiter ? ','
     _unit_pos   = opts.unit_position ? 'start'
 
+    sign = ''
+
     # Non-number values return zero precision
     if isNaN(float)
-      integer = float
-      _separator = decimal = ''
+      result = float
     else
-      number  = float.toString().split('.')
-      integer = parseInt(number[0], 10)
-      decimal = number[1]
-
-      # Pad to _precision
-      decimal = parseFloat("0.#{decimal}").toFixed(_precision)
-      decimal = decimal.toString().split('.')
-
-      carry = parseInt(decimal[0], 10)
-      integer += carry if carry
-
-      decimal = decimal[1] ? ''
-
-      # Remove separator if no decimal
-      _separator = '' unless decimal
-
-
-      integer = NumberHelpers.number_with_delimiter(integer, {delimiter: _delimiter})
+      float = parseFloat(float) # Arg might be a string, integer
+      sign = '-' if float < 0
+      fixedWidth = Math.abs(float).toFixed(_precision)
+      delimited = NumberHelpers.number_with_delimiter(fixedWidth, {delimiter: _delimiter})
+      result = delimited.split('.').join(_separator)
 
     if _unit_pos == 'end'
-      return "#{integer}#{_separator}#{decimal}#{_unit}"
+      return "#{sign}#{result}#{_unit}"
     else
-      return "#{_unit}#{integer}#{_separator}#{decimal}"
+      return "#{sign}#{_unit}#{result}"
 
   @number_with_delimiter = (float, opts={}) ->
     _separator  = opts.separator ? '.'
@@ -47,7 +35,7 @@ class @NumberHelpers
     _separator = '' unless decimal
 
     rgx = /(\d+)(\d{3})/
-    integer = integer .replace(rgx, "$1" + _delimiter + "$2") while rgx.test(integer) if _delimiter
+    integer = integer.replace(rgx, "$1" + _delimiter + "$2") while rgx.test(integer) if _delimiter
 
     return "#{integer}#{_separator}#{decimal}"
 

--- a/js/number_helpers.js
+++ b/js/number_helpers.js
@@ -4,7 +4,7 @@
     function NumberHelpers() {}
 
     NumberHelpers.number_to_currency = function(float, opts) {
-      var carry, decimal, integer, number, _delimiter, _precision, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _separator, _unit, _unit_pos;
+      var delimited, fixedWidth, result, sign, _delimiter, _precision, _ref, _ref1, _ref2, _ref3, _ref4, _separator, _unit, _unit_pos;
       if (opts == null) {
         opts = {};
       }
@@ -13,31 +13,24 @@
       _separator = (_ref2 = opts.separator) != null ? _ref2 : '.';
       _delimiter = (_ref3 = opts.delimiter) != null ? _ref3 : ',';
       _unit_pos = (_ref4 = opts.unit_position) != null ? _ref4 : 'start';
+      sign = '';
       if (isNaN(float)) {
-        integer = float;
-        _separator = decimal = '';
+        result = float;
       } else {
-        number = float.toString().split('.');
-        integer = parseInt(number[0], 10);
-        decimal = number[1];
-        decimal = parseFloat("0." + decimal).toFixed(_precision);
-        decimal = decimal.toString().split('.');
-        carry = parseInt(decimal[0], 10);
-        if (carry) {
-          integer += carry;
+        float = parseFloat(float);
+        if (float < 0) {
+          sign = '-';
         }
-        decimal = (_ref5 = decimal[1]) != null ? _ref5 : '';
-        if (!decimal) {
-          _separator = '';
-        }
-        integer = NumberHelpers.number_with_delimiter(integer, {
+        fixedWidth = Math.abs(float).toFixed(_precision);
+        delimited = NumberHelpers.number_with_delimiter(fixedWidth, {
           delimiter: _delimiter
         });
+        result = delimited.split('.').join(_separator);
       }
       if (_unit_pos === 'end') {
-        return "" + integer + _separator + decimal + _unit;
+        return "" + sign + result + _unit;
       } else {
-        return "" + _unit + integer + _separator + decimal;
+        return "" + sign + _unit + result;
       }
     };
 

--- a/specs/NumberToCurrencySpec.js
+++ b/specs/NumberToCurrencySpec.js
@@ -10,6 +10,18 @@ describe("Number To Currency", function() {
     var out = NumberHelpers.number_to_currency('1234567890.50');
     expect(out).toBe('$1,234,567,890.50');
   });
+  it('Negative number', function() {
+    var out = NumberHelpers.number_to_currency(-2.99, {precision: 0});
+    expect(out).toBe('-$3');
+  });
+  it('Negative number with precision rounding', function() {
+    var out = NumberHelpers.number_to_currency(-2.999, {precision: 2});
+    expect(out).toBe('-$3.00');
+  });
+  it('Negative number with precision', function() {
+    var out = NumberHelpers.number_to_currency(-2.503, {precision: 2});
+    expect(out).toBe('-$2.50');
+  });
   it('Rounding Up', function() {
     var out = NumberHelpers.number_to_currency(1234567890.506);
     expect(out).toBe('$1,234,567,890.51');


### PR DESCRIPTION
NumbersHelper.number_to_currency(-2.99) should return "-$3", not
"$-3". This is consistent with what rails does.

I also did a rather significant refactor of the function. Let me know
if this is poor CoffeeScript style; I'm very new to the language.
